### PR TITLE
Make numsamples declaration unconditional; fixes compiler error

### DIFF
--- a/rtl_redsea.c
+++ b/rtl_redsea.c
@@ -122,8 +122,8 @@ int main(int argc, char **argv) {
   reading_frame = 0;
   qua = 0;
   double t = 0;
-  int numsamples = 0;
 #endif
+  int numsamples = 0;
 
   while ((c = getopt (argc, argv, "f:")) != -1)
     switch (c) {


### PR DESCRIPTION
This change fixes a compiler error that I got when following the build instructions.