### PR TITLE
Reduce the writes calls to output stream using streamstring

### DIFF
--- a/src/groups.cc
+++ b/src/groups.cc
@@ -72,7 +72,7 @@ void PrintHexGroup(const Group& group, std::ostream* stream,
   if (group.has_time())
     *stream << " " << TimePointToString(group.rx_time(), time_format);
 
-  *stream << '\n';
+  *stream << '\n' << std::flush;
 }
 
 GroupType::GroupType(uint16_t type_code) :
@@ -292,9 +292,11 @@ void Station::UpdateAndPrint(const Group& group, std::ostream* stream) {
       json_["debug"].append("TODO " + group.type().str());
   }
 
-  writer_->write(json_, stream);
+  std::stringstream ss;
+  writer_->write(json_, &ss);
+  ss << '\n';
 
-  *stream << '\n';
+  *stream << ss.str() << std::flush;
 }
 
 uint16_t Station::pi() const {

--- a/src/redsea.cc
+++ b/src/redsea.cc
@@ -182,12 +182,6 @@ int main(int argc, char** argv) {
   redsea::Station station(pi, options);
   redsea::RunningAverage bler_average(redsea::kNumBlerAverageGroups);
 
-  // Line buffering
-  if (options.feed_thru)
-    setvbuf(stderr, NULL, _IOLBF, 2048);
-  else
-    setvbuf(stdout, NULL, _IOLBF, 2048);
-
   while (!(std::cin.eof() || block_stream.eof())) {
     redsea::Group group = (options.input_type == redsea::INPUT_HEX ?
         redsea::ReadNextHexGroup(options) :


### PR DESCRIPTION
This commit reduces the number of write calls to output stream
by writing all calls to an intermediate stringstream.
Then we are writing the contents of stringstream to out stream
followed by the flush to make sure the data will apper asap on
the output.

The line buffering also was removed, apperently it didn't work
as expcected.

Before applying this commit several write calls occured:

write(2, "{", 1{)                        = 1
write(2, "\"di\"", 4"di")                   = 4
write(2, ":", 1:)                        = 1
write(2, "{", 1{)                        = 1
write(2, "\"compressed\"", 12"compressed")          = 12
write(2, ":", 1:)                        = 1
write(2, "false", 5false)                    = 5
write(2, "}", 1})                        = 1
write(2, ",", 1,)                        = 1
write(2, "\"group\"", 7"group")                = 7
write(2, ":", 1:)                        = 1
write(2, "\"0A\"", 4"0A")                   = 4
write(2, ",", 1,)                        = 1
write(2, "\"is_music\"", 10"is_music")            = 10
write(2, ":", 1:)                        = 1
write(2, "true", 4true)                     = 4
write(2, ",", 1,)                        = 1
write(2, "\"pi\"", 4"pi")                   = 4
write(2, ":", 1:)                        = 1
write(2, "\"0x1367\"", 8"0x1367")               = 8
write(2, ",", 1,)                        = 1
write(2, "\"prog_type\"", 11"prog_type")           = 11
write(2, ":", 1:)                        = 1
write(2, "\"Easy listening\"", 16"Easy listening")      = 16
write(2, ",", 1,)                        = 1
write(2, "\"ta\"", 4"ta")                   = 4
write(2, ":", 1:)                        = 1
write(2, "false", 5false)                    = 5
write(2, ",", 1,)                        = 1
write(2, "\"tp\"", 4"tp")                   = 4
write(2, ":", 1:)                        = 1
write(2, "true", 4true)                     = 4
write(2, "}", 1})                        = 1
write(2, "\n", 1
)                       = 1

With the patch applied the data received on one write call.

write(2, "{\"di\":{\"stereo\":false},\"group\":\""..., 117{"di":{"stereo":false},"group":"0A","is_music":true,"pi":"0x1367","prog_type":"Easy listening","ta":false,"tp":true}
) = 117

On the PrintHexGroup, only flush required, most probably because stdin is buffered by default.