### PR TITLE
Update README.md for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ beginning.
 
 Or on macOS (OSX) using Homebrew:
 
-        $ brew install autoconf libsndfile liquid-dsp
+        $ brew install autoconf automake libsndfile liquid-dsp
         $ xcode-select --install
 
 2. Clone the repository (unless you downloaded a release zip file):


### PR DESCRIPTION
We also need to install `automake` with Homebrew, in order to get `aclocal(1)`