### PR TITLE
Automake fixes for Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,10 +58,29 @@ AC_CHECK_LIB([sndfile], [main],
   [AC_MSG_FAILURE(
      [Could not find libsndfile])])
 
+WIN_CF=
+LIBC=
+
+AC_MSG_CHECKING([whether compiling for Windows])
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#if !defined(_WIN32) && !defined(_WIN64)
+#error not compiling for Windows
+#endif
+]])], 
+  # Windows
+  [AC_MSG_RESULT([yes]); AC_SUBST([WIN_CF], ["-D_USE_MATH_DEFINES=1"])],
+  # Unix
+  [AC_MSG_RESULT([no]); AC_SUBST([LIBC], ["-lc"])])
+
+CPP_STD=c++14
 AC_CANONICAL_HOST
 case "${host_os}" in
-  darwin*)
+  darwin*|msys*|mingw*)
       AC_SUBST([ICONV], ["-liconv"])
+      ;;
+  cygwin*)
+      AC_SUBST([ICONV], ["-liconv"])
+      AC_SUBST([CPP_STD], ["gnu++14"])
       ;;
 esac
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,7 +1,7 @@
 bin_PROGRAMS = redsea
-redsea_CPPFLAGS = -std=c++14 -Wall -Wextra -Wstrict-overflow -Wshadow -Wdouble-promotion -Wundef -Wpointer-arith -Wcast-align -Wcast-qual -Wuninitialized -pedantic \
-									$(MACPORTS_CF) $(RFLAGS)
-redsea_LDADD = $(MACPORTS_LD) -lc $(LIQUID) $(ICONV) $(SNDFILE)
+redsea_CPPFLAGS = -std=$(CPP_STD) -Wall -Wextra -Wstrict-overflow -Wshadow -Wdouble-promotion -Wundef -Wpointer-arith -Wcast-align -Wcast-qual -Wuninitialized -pedantic \
+									$(MACPORTS_CF) $(RFLAGS) $(WIN_CF)
+redsea_LDADD = $(MACPORTS_LD) $(LIBC) $(LIQUID) $(ICONV) $(SNDFILE)
 redsea_SOURCES = redsea.cc common.cc input.cc subcarrier.cc block_sync.cc groups.cc \
 								 tables.cc rdsstring.cc tmc/tmc.cc tmc/locationdb.cc util.cc \
 								 channel.cc options.cc liquid_wrappers.cc jsoncpp.cpp


### PR DESCRIPTION
Introduces some changes to allow easier compilation for Windows-targets/environments.

Summary of changes:
- Detect Windows compilation target (including cross-compile)
- Linker options for libiconv on MSYS, Cygwin and MinGW environments
- Enables GNU extensions in Cygwin