### PR TITLE
Building tests is optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Install dependencies (brew)
       run: brew install meson libsndfile liquid-dsp nlohmann-json catch2 perl gcovr
     - name: meson setup
-      run: meson setup -Dwerror=true -Db_sanitize=address,undefined -Db_lundef=false -Db_coverage=true build
+      run: meson setup -Dwerror=true -Db_sanitize=address,undefined -Db_lundef=false -Db_coverage=true build -Dbuild_tests=true
     - name: compile & install
       run: cd build && meson install
     - name: download test data

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
     'prefix=/usr/local',
     'cpp_std=c++14',
   ],
-  version: '1.1.0',
+  version: '1.1.1-SNAPSHOT',
 )
 
 # Store version number to be compiled in
@@ -121,9 +121,11 @@ executable(
 ### Unit tests ###
 ##################
 
-catch2 = dependency('catch2-with-main', required: false)
+build_tests = get_option('build_tests')
 
-if catch2.found()
+if build_tests
+  catch2 = dependency('catch2-with-main', required: true)
+
   unit_test_exe = executable(
     'redsea-test-unit',
     [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('build_tests', type: 'boolean', value: false, description: 'Build unit tests (requires Catch2)')


### PR DESCRIPTION
It's better to base the test-building condition on a command-line option instead of the presence of Catch2. Building the tests is not necessary for normal usage of redsea anyway.