### PR TITLE
Remove codecov reporting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,9 +79,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies (brew)
-      run: brew install meson libsndfile liquid-dsp nlohmann-json catch2 perl gcovr
+      run: brew install meson libsndfile liquid-dsp nlohmann-json catch2 perl
     - name: meson setup
-      run: meson setup -Dwerror=true -Db_sanitize=address,undefined -Db_lundef=false -Db_coverage=true build -Dbuild_tests=true
+      run: meson setup -Dwerror=true -Db_sanitize=address,undefined -Db_lundef=false build -Dbuild_tests=true
     - name: compile & install
       run: cd build && meson install
     - name: download test data
@@ -90,13 +90,6 @@ jobs:
       run: cd build && meson test
     - name: Test command-line interface
       run: perl test/cli.pl redsea --installed
-    - name: Coverage
-      run: cd build && ninja coverage-xml
-    - name: Upload to Codecov
-      uses: codecov/codecov-action@v4
-      with:
-        files: build/meson-logs/coverage.xml
-        token: ${{ secrets.CODECOV_TOKEN }}
 
   build-windows-msys2-mingw:
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ decoder that supports many [RDS features][Wiki: Features].
 
 [![release](https://img.shields.io/github/release/windytan/redsea.svg)](https://github.com/windytan/redsea/releases/latest)
 [![build](https://github.com/windytan/redsea/workflows/build/badge.svg)](https://github.com/windytan/redsea/actions/workflows/build.yml?query=branch%3Amaster)
-[![codecov](https://codecov.io/github/windytan/redsea/graph/badge.svg?token=rlYtqSE4Cx)](https://codecov.io/github/windytan/redsea)
 
 It prints [newline-delimited JSON](https://jsonlines.org/) where
 each line corresponds to one RDS group. It can also print "raw" undecoded hex blocks (`--output hex`).

--- a/src/block_sync.h
+++ b/src/block_sync.h
@@ -65,11 +65,11 @@ class BlockStream {
   uint32_t input_register_{0};
   Offset expected_offset_{Offset::A};
   bool is_in_sync_{false};
-  RunningSum<int, 50> block_error_sum50_{};
+  RunningSum<int, 50> block_error_sum50_;
   const Options options_{};
-  RunningAverage<float, kNumBlerAverageGroups> bler_average_{};
-  Group current_group_{};
-  Group ready_group_{};
+  RunningAverage<float, kNumBlerAverageGroups> bler_average_;
+  Group current_group_;
+  Group ready_group_;
   bool has_group_ready_{false};
   uint32_t num_bits_since_sync_lost_{0};
   SyncPulseBuffer sync_buffer_{};

--- a/src/channel.h
+++ b/src/channel.h
@@ -85,11 +85,11 @@ class Channel {
   Options options_{};
   int which_channel_{};
   std::ostream& output_stream_;
-  CachedPI cached_pi_{};
+  CachedPI cached_pi_;
   BlockStream block_stream_;
   Station station_;
-  RunningAverage<float, kNumBlerAverageGroups> bler_average_{};
-  std::chrono::time_point<std::chrono::system_clock> last_group_rx_time_{};
+  RunningAverage<float, kNumBlerAverageGroups> bler_average_;
+  std::chrono::time_point<std::chrono::system_clock> last_group_rx_time_;
 };
 
 }  // namespace redsea

--- a/src/groups.h
+++ b/src/groups.h
@@ -173,7 +173,7 @@ class Group {
   void setAverageBLER(float bler);
 
  private:
-  GroupType type_{};
+  GroupType type_;
   std::array<Block, 4> blocks_;
   std::chrono::time_point<std::chrono::system_clock> time_received_;
   float bler_{0.f};

--- a/src/input.cc
+++ b/src/input.cc
@@ -247,6 +247,7 @@ Group readTEFGroup(const Options& options) {
         block1.data        = static_cast<uint16_t>(std::stol(line, nullptr, 16));
         block1.is_received = true;
       } catch (const std::exception&) {
+        continue;
       }
       group.setBlock(BLOCK1, block1);
     } else if (line.substr(0, 1) == "R" && line.length() >= 15) {
@@ -270,6 +271,7 @@ Group readTEFGroup(const Options& options) {
         group.setBlock(BLOCK3, blocks[1]);
         group.setBlock(BLOCK4, blocks[2]);
       } catch (const std::exception&) {
+        break;
       }
       break;
     }

--- a/src/rdsstring.h
+++ b/src/rdsstring.h
@@ -55,7 +55,7 @@ class RDSString {
   size_t prev_pos_{};
   size_t sequential_length_{};
   // Decoded string.
-  std::string last_complete_string_{};
+  std::string last_complete_string_;
 };
 
 }  // namespace redsea


### PR DESCRIPTION
Codecov included a bunch of STL headers in the report and was not
useful. Coverage can still be calculated locally with:

    meson setup -Db_coverage=true build -Dbuild_tests=true
    cd build
    meson compile
    meson test
    ninja coverage-html