### PR TITLE
Use std::endl instead of '\n'

### DIFF
--- a/src/groups.cc
+++ b/src/groups.cc
@@ -321,11 +321,11 @@ void Station::updateAndPrint(const Group& group, std::ostream& stream) {
     // incomplete JSON objects could get printed.
     std::stringstream output_proxy_stream;
     output_proxy_stream << json_;
-    stream << output_proxy_stream.str() << '\n';
+    stream << output_proxy_stream.str() << std::endl;
   } catch (const std::exception& e) {
     nlohmann::ordered_json json_from_exception;
     json_from_exception["debug"] = std::string(e.what());
-    stream << json_from_exception << '\n';
+    stream << json_from_exception << std::endl;
   }
 }
 


### PR DESCRIPTION
I'm using redsea with Golang's `exec.Cmd`. Since the newline delimiter was changed from `std::endl` to `'\n'`, I'm unable to read each line of JSON in real time and instead get large chunks of JSON lines printed infrequently. I believe it's becuase `std::endl` flushes the output buffer whereas `'\n'` doesn't.

Changing the newline delimiter back to `std::endl` fixes this issue for me.