### PR TITLE
Add RDS2 streams + RFT support

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks: >
   modernize-*,
   -modernize-use-trailing-return-type,
   performance-*,
+  -performance-avoid-endl,
   portability-*,
   readability-misplaced-array-index,
   readability-redundant-*,

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 We use [semantic versioning](https://semver.org/).
 
+## 1.2.0-SNAPSHOT (HEAD)
+
+* Major new features:
+  * Add RDS2 streams / RFT support (#32): --streams
+
 ## 1.1.1 (2025-03-03)
 
 * Bug fixes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,16 @@ Some guidelines for making good bug reports:
   solution! It's possible that others will also run into similar problems.
 * Please be patient with it; Redsea is a single-maintainer hobby project.
 
+## How to build and run the tests
+
+Install Catch2, then in the redsea root run:
+
+    git lfs pull
+    meson setup build -Dbuild_tests=true
+    cd build
+    meson compile
+    meson test
+
 ## General PR guidelines
 
 You can directly contribute to the source code via pull requests. We have a

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
     'prefix=/usr/local',
     'cpp_std=c++14',
   ],
-  version: '1.1.1',
+  version: '1.2.0-SNAPSHOT',
 )
 
 # Store version number to be compiled in
@@ -22,11 +22,6 @@ configure_file(output: 'config.h', configuration: conf)
 
 cc = meson.get_compiler('cpp')
 add_project_arguments(cc.get_supported_arguments(['-Wno-unknown-pragmas']), language: 'cpp')
-
-# We want to use M_PI on Windows
-if build_machine.system() == 'windows'
-  add_project_arguments('-D_USE_MATH_DEFINES=1', language: 'cpp')
-endif
 
 # Explicit GNU extensions on Cygwin
 if build_machine.system() == 'cygwin'

--- a/src/base64.hh
+++ b/src/base64.hh
@@ -1,0 +1,57 @@
+#ifndef BASE64_H_
+#define BASE64_H_
+
+#include <cstdint>
+#include <string>
+
+namespace redsea {
+
+inline std::string asBase64(const void* data, std::size_t input_length) {
+  constexpr char base64_table[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+  if (data == nullptr || input_length == 0) {
+    return "";
+  }
+
+  const auto* bytes = static_cast<const std::uint8_t*>(data);
+
+  const std::size_t output_length = ((input_length + 2) / 3) * 4;
+  std::string encoded;
+  encoded.reserve(output_length);
+
+  // Process input in 3-byte chunks
+  for (std::size_t i = 0; i < input_length; i += 3) {
+    std::uint32_t chunk = 0;
+    int nbytes_in_chunk = 0;
+
+    for (int j = 0; j < 3; ++j) {
+      if (i + j < input_length) {
+        chunk |= static_cast<std::uint32_t>(bytes[i + j]) << (16 - j * 8);
+        ++nbytes_in_chunk;
+      }
+    }
+
+    // Encode 4 Base64 characters
+    encoded.push_back(base64_table[(chunk >> 18) & 0x3F]);
+    encoded.push_back(base64_table[(chunk >> 12) & 0x3F]);
+
+    if (nbytes_in_chunk > 1) {
+      encoded.push_back(base64_table[(chunk >> 6) & 0x3F]);
+    } else {
+      encoded.push_back('=');
+    }
+
+    if (nbytes_in_chunk == 3) {
+      encoded.push_back(base64_table[chunk & 0x3F]);
+    } else {
+      encoded.push_back('=');
+    }
+  }
+
+  return encoded;
+}
+
+}  // namespace redsea
+
+#endif  // BASE64_H_

--- a/src/block_sync.cc
+++ b/src/block_sync.cc
@@ -219,7 +219,9 @@ bool SyncPulseBuffer::isSequenceFound() const {
   return false;
 }
 
-BlockStream::BlockStream(const Options& options) : options_(options) {}
+void BlockStream::init(const Options& options) {
+  options_ = options;
+}
 
 // Try to find a cyclic pattern in the offset words.
 void BlockStream::acquireSync(Block block) {

--- a/src/block_sync.h
+++ b/src/block_sync.h
@@ -48,7 +48,8 @@ struct ErrorCorrectionResult {
 
 class BlockStream {
  public:
-  explicit BlockStream(const Options& options);
+  BlockStream() = default;
+  void init(const Options& options);
   void pushBit(bool bit);
   Group popGroup();
   bool hasGroupReady() const;
@@ -66,7 +67,7 @@ class BlockStream {
   Offset expected_offset_{Offset::A};
   bool is_in_sync_{false};
   RunningSum<int, 50> block_error_sum50_;
-  const Options options_{};
+  Options options_{};
   RunningAverage<float, kNumBlerAverageGroups> bler_average_;
   Group current_group_;
   Group ready_group_;

--- a/src/channel.h
+++ b/src/channel.h
@@ -17,6 +17,7 @@
 #ifndef CHANNEL_H_
 #define CHANNEL_H_
 
+#include <array>
 #include <iostream>
 
 #include "src/block_sync.h"
@@ -74,9 +75,9 @@ class Channel {
  public:
   Channel(const Options& options, int which_channel, std::ostream& output_stream);
   Channel(const Options& options, std::ostream& output_stream, uint16_t pi);
-  void processBit(bool bit);
-  void processBits(const BitBuffer& buffer);
-  void processGroup(Group group);
+  void processBit(bool bit, std::size_t which_stream);
+  void processBits(const BitBuffer& buffer, std::size_t which_stream);
+  void processGroup(Group group, std::size_t which_stream);
   void flush();
   float getSecondsSinceCarrierLost() const;
   void resetPI();
@@ -86,7 +87,7 @@ class Channel {
   int which_channel_{};
   std::ostream& output_stream_;
   CachedPI cached_pi_;
-  BlockStream block_stream_;
+  std::array<BlockStream, 4> block_stream_;
   Station station_;
   RunningAverage<float, kNumBlerAverageGroups> bler_average_;
   std::chrono::time_point<std::chrono::system_clock> last_group_rx_time_;

--- a/src/common.h
+++ b/src/common.h
@@ -17,6 +17,7 @@
 #ifndef COMMON_H_
 #define COMMON_H_
 
+#include <array>
 #include <chrono>
 #include <vector>
 
@@ -37,7 +38,8 @@ constexpr float kMaxResampleRatio = kTargetSampleRate_Hz / kMinimumSampleRate_Hz
 
 struct BitBuffer {
   std::chrono::time_point<std::chrono::system_clock> time_received;
-  std::vector<bool> bits;
+  // One vector for each data-stream
+  std::array<std::vector<int>, 4> bits;
 };
 
 }  // namespace redsea

--- a/src/options.h
+++ b/src/options.h
@@ -40,6 +40,7 @@ struct Options {
   bool is_rate_defined{};
   bool is_num_channels_defined{};
   bool use_fec{true};
+  bool streams{};
   float samplerate{};
   uint32_t num_channels{1};
   InputType input_type{InputType::MPX_stdin};

--- a/src/rft.hh
+++ b/src/rft.hh
@@ -1,0 +1,113 @@
+#ifndef RFT_HH_
+#define RFT_HH_
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "base64.hh"
+#include "util.h"
+
+namespace redsea {
+
+struct RFTSegment {
+  std::array<std::uint8_t, 5> bytes;
+};
+
+class RFTFile {
+ public:
+  RFTFile() = default;
+
+  // \note Does nothing if size is too large
+  void setSize(std::uint32_t size) {
+    constexpr std::uint32_t kMaxSize = kMaxNumSegments * sizeof(RFTSegment);
+    if (size <= kMaxSize)
+      expected_size_bytes_ = size;
+  }
+
+  void clear() {
+    for (std::size_t i = 0; i < received_.size(); i++) {
+      received_[i] = false;
+    }
+    is_printed_ = false;
+  }
+
+  // \param flag 0: no CRC, 1: CRC
+  void setCRCFlag(int flag) {
+    expect_crc_ = flag;
+  }
+  // \param crc Expected crc16_ccitt
+  // \note TODO CRC mode
+  void setExpectedCRC(std::uint16_t expected_crc) {
+    expected_crc_ = expected_crc;
+  }
+
+  // Receive segment data for this file
+  // \param toggle RFT toggle bit
+  // \param segment_address 0..32767
+  void receive(int toggle, std::uint32_t segment_address, std::uint16_t block2,
+               std::uint16_t block3, std::uint16_t block4) {
+    // To prevent having to hold 16 x 170 kB buffers at all times, memory is allocated when
+    // the first group is received on this pipe
+    // (vector::resize() is a no-op on subsequent calls)
+    received_.resize(kMaxNumSegments);
+    data_.resize(kMaxNumSegments);
+
+    // File contents changed
+    if (toggle != prev_toggle_) {
+      clear();
+    }
+    prev_toggle_ = toggle;
+
+    if (segment_address < kMaxNumSegments) {
+      RFTSegment segment;
+      segment.bytes = {
+          static_cast<uint8_t>(getBits<8>(block2, 0)), static_cast<uint8_t>(getBits<8>(block3, 8)),
+          static_cast<uint8_t>(getBits<8>(block3, 0)), static_cast<uint8_t>(getBits<8>(block4, 8)),
+          static_cast<uint8_t>(getBits<8>(block4, 0))};
+      data_[segment_address]     = segment;
+      received_[segment_address] = true;
+    }
+  }
+
+  bool hasNewCompleteFile() const {
+    if (is_printed_)
+      return false;
+    if (expected_size_bytes_ == 0)
+      return false;
+    if (received_.empty())
+      return false;
+
+    const std::size_t expected_num_segments = divideRoundingUp(expected_size_bytes_, 5U);
+    for (std::size_t i = 0; i < expected_num_segments; i++) {
+      if (!received_[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  // Return the file contents encoded as PEM Base64
+  std::string getBase64Data() {
+    is_printed_ = true;
+    return asBase64(data_.data(), expected_size_bytes_);
+  }
+
+ private:
+  static constexpr size_t kMaxNumSegments = 1 << 15;
+
+  // 163.8 kB buffer in heap
+  std::vector<RFTSegment> data_;
+  // ~4 kB buffer in heap
+  std::vector<bool> received_;
+  std::uint32_t expected_size_bytes_{};
+  bool is_printed_{};
+  bool expect_crc_{};
+  std::uint16_t expected_crc_{};
+  int prev_toggle_{};
+};
+
+}  // namespace redsea
+
+#endif  // RFT_HH_

--- a/src/util.cc
+++ b/src/util.cc
@@ -28,6 +28,20 @@ std::string getHoursMinutesString(int hour, int minute) {
   return ss.str();
 }
 
+// Used in RDS2 RFT
+uint32_t crc16_ccitt(const uint8_t* data, size_t length) {
+  uint32_t crc = 0xFFFF;
+
+  for (size_t i = 0; i < length; ++i) {
+    crc = static_cast<uint8_t>(crc >> 8) | (crc << 8);
+    crc ^= data[i];
+    crc ^= static_cast<uint8_t>(crc & 0xFF) >> 4;
+    crc ^= (crc << 8) << 4;
+    crc ^= ((crc & 0xFF) << 4) << 1;
+  }
+  return (crc ^ 0xFFFF) & 0xFFFF;
+}
+
 std::string getTimePointString(const std::chrono::time_point<std::chrono::system_clock>& timepoint,
                                const std::string& format) {
   // This is done to ensure we get truncation and not rounding to integer seconds

--- a/src/util.h
+++ b/src/util.h
@@ -58,6 +58,12 @@ inline uint8_t getUint8(uint16_t word, size_t bit_pos) {
   return static_cast<uint8_t>(getBits<8>(word, bit_pos));
 }
 
+template <typename T>
+constexpr T divideRoundingUp(T dividend, T divisor) {
+  static_assert(std::is_integral<T>::value, "");
+  return (dividend + divisor - 1) / divisor;
+}
+
 std::string getHoursMinutesString(int hour, int minute);
 std::string getTimePointString(const std::chrono::time_point<std::chrono::system_clock>& timepoint,
                                const std::string& format);
@@ -81,6 +87,8 @@ template <int N>
 std::string getPrefixedHexString(uint32_t value) {
   return "0x" + getHexString<N>(value);
 }
+
+unsigned int crc16_ccitt(const uint8_t* data, size_t length);
 
 class CarrierFrequency {
  public:

--- a/test/resources/rds2-minirds-192k.flac
+++ b/test/resources/rds2-minirds-192k.flac
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d2d83af603a70b2ef4e55084222550b79bf00613fe9c353e7916b325c3986a5
+size 292551

--- a/test/test_helpers.h
+++ b/test/test_helpers.h
@@ -49,7 +49,7 @@ inline std::vector<nlohmann::ordered_json> asciibin2json(const std::string& bind
   for (const auto& ascii_bit : bindata) {
     const int bit{ascii_bit == '1' ? 1 : 0};
 
-    channel.processBit(bit);
+    channel.processBit(bit, 0);
     if (!json_stream.str().empty()) {
       nlohmann::ordered_json jsonroot;
       json_stream >> jsonroot;
@@ -67,7 +67,8 @@ inline std::vector<nlohmann::ordered_json> asciibin2json(const std::string& bind
 inline std::vector<redsea::Group> asciibin2groups(const std::string& bindata,
                                                   const redsea::Options& options) {
   std::vector<redsea::Group> result;
-  redsea::BlockStream block_stream(options);
+  redsea::BlockStream block_stream;
+  block_stream.init(options);
 
   for (const auto& ascii_bit : bindata) {
     const int bit{ascii_bit == '1' ? 1 : 0};
@@ -92,7 +93,7 @@ inline std::vector<nlohmann::ordered_json> groups2json(const std::vector<redsea:
   for (const auto& group : data) {
     json_stream.str("");
     json_stream.clear();
-    channel.processGroup(group);
+    channel.processGroup(group, 0);
     if (!json_stream.str().empty()) {
       nlohmann::ordered_json jsonroot;
       json_stream >> jsonroot;

--- a/test/unit.cc
+++ b/test/unit.cc
@@ -1130,3 +1130,42 @@ TEST_CASE("Clock-time formatting") {
     CHECK(time_string.substr(7, 4) == "0.00");
   }
 }
+
+TEST_CASE("CRC16") {
+  // Pg. 84
+  const std::vector<uint8_t> test_bytes{0x32, 0x44, 0x31, 0x31, 0x31, 0x32, 0x33, 0x34, 0x30, 0x31,
+                                        0x30, 0x31, 0x30, 0x35, 0x41, 0x42, 0x43, 0x44, 0x31, 0x32,
+                                        0x33, 0x46, 0x30, 0x58, 0x58, 0x58, 0x58, 0x31, 0x31, 0x30,
+                                        0x36, 0x39, 0x32, 0x31, 0x32, 0x34, 0x39, 0x31, 0x30, 0x30,
+                                        0x30, 0x33, 0x32, 0x30, 0x30, 0x36, 0x36};
+  const uint16_t expected_crc = 0x9723;
+  const uint16_t crc          = redsea::crc16_ccitt(test_bytes.data(), test_bytes.size());
+  CHECK(crc == expected_crc);
+}
+
+TEST_CASE("Base64 encoding") {
+  const std::string test_string1{"light wor"};
+  const std::string encoded1 = redsea::asBase64(test_string1.c_str(), test_string1.size());
+  CHECK(encoded1 == "bGlnaHQgd29y");
+
+  const std::string test_string2{"light wo"};
+  const std::string encoded2 = redsea::asBase64(test_string2.c_str(), test_string2.size());
+  CHECK(encoded2 == "bGlnaHQgd28=");
+
+  const std::string test_string3{"light w"};
+  const std::string encoded3 = redsea::asBase64(test_string3.c_str(), test_string3.size());
+  CHECK(encoded3 == "bGlnaHQgdw==");
+
+  const std::string test_string4{""};
+  const std::string encoded4 = redsea::asBase64(test_string4.c_str(), test_string4.size());
+  CHECK(encoded4 == "");
+}
+
+TEST_CASE("Round-up division") {
+  CHECK(redsea::divideRoundingUp(5, 2) == 3);
+  CHECK(redsea::divideRoundingUp(4, 2) == 2);
+  CHECK(redsea::divideRoundingUp(3, 2) == 2);
+  CHECK(redsea::divideRoundingUp(2, 2) == 1);
+  CHECK(redsea::divideRoundingUp(1, 2) == 1);
+  CHECK(redsea::divideRoundingUp(0, 2) == 0);
+}


### PR DESCRIPTION
(Note that everything about how this works may still change, it's WIP)

Redsea can now receive the extra data streams 1, 2, and 3 introduced in RDS 2. See #32 and #102 . To keep redsea fast this feature is not enabled by default; Use the option `--streams` to enable it.

The streams are often used to transfer small files, typically the station logo. Redsea prints these files along the normal JSON output. The JSON field `.rft.file_contents` contains the entire file as base64.

Sometimes these lines will get very long and copy-pasting from terminal is not easy. You can use this string of commands to save the first file in a pre-recorded signal to disk:

```bash
redsea --streams -f input_file.wav |\
  grep file_contents |\
  head --lines=1 |\
  jq --raw-output .rft.file_contents |\
  base64 --decode > rft_file.bin
```

Use the command `file --extension rft_file.bin` to find out the image format. Rename the file appropriately so you can open it.
