### PR TITLE
Fix eRT decoding: resize buffer to 128 bytes, add UTF-8 validation

### DIFF
--- a/src/text/rdsstring.cc
+++ b/src/text/rdsstring.cc
@@ -142,8 +142,7 @@ std::string sanitizeUtf8(const std::string& src) {
     if (i + seq_len > src.size()) {
       // Incomplete sequence at end of string
       result += '?';
-      i++;
-      continue;
+      break;
     }
 
     // Validate continuation bytes (must be 10xxxxxx)

--- a/src/text/rdsstring.hh
+++ b/src/text/rdsstring.hh
@@ -59,5 +59,9 @@ class RDSString {
   std::string last_complete_string_;
 };
 
+// Sanitize a UTF-8 string by replacing invalid/incomplete sequences with '?'.
+// This ensures the output is always valid UTF-8 for JSON serialization.
+std::string sanitizeUtf8(const std::string& src);
+
 }  // namespace redsea
 #endif  // RDSSTRING_H_


### PR DESCRIPTION
- Resize eRT buffer from 64 to 128 bytes per IEC 62106-6, fixes #149 
- Add sanitizeUtf8() to handle incomplete multi-byte sequences, fixes #150 
- Fix off-by-one in RT+/eRT+ tag extraction at string end, fixes #151 
